### PR TITLE
Fix the newValues provided to a listener for SimpleListProperty.set

### DIFF
--- a/validationframework-core/src/main/java/com/google/code/validationframework/base/property/simple/SimpleListProperty.java
+++ b/validationframework-core/src/main/java/com/google/code/validationframework/base/property/simple/SimpleListProperty.java
@@ -134,7 +134,7 @@ public class SimpleListProperty<T> extends AbstractReadableWritableListProperty<
 
         if (!ValueUtils.areEqual(oldItem, item)) {
             List<T> oldItems = Collections.unmodifiableList(Collections.singletonList(oldItem));
-            List<T> newItems = Collections.unmodifiableList(Collections.singletonList(oldItem));
+            List<T> newItems = Collections.unmodifiableList(Collections.singletonList(item));
             doNotifyListenersOfChangedValues(index, oldItems, newItems);
         }
 

--- a/validationframework-core/src/test/java/com/google/code/validationframework/base/property/simple/SimpleListPropertyTest.java
+++ b/validationframework-core/src/test/java/com/google/code/validationframework/base/property/simple/SimpleListPropertyTest.java
@@ -244,6 +244,25 @@ public class SimpleListPropertyTest {
     }
 
     @Test
+    public void testSet() {
+        List<String> refAll = new ArrayList<String>();
+        refAll.add("A");
+        refAll.add("B");
+        refAll.add("C");
+
+        SimpleListProperty<String> property = new SimpleListProperty<String>(refAll);
+        ListValueChangeListener<String> listener = mock(ListValueChangeListener.class);
+        property.addValueChangeListener(listener);
+
+        property.set(1, "D");
+        refAll.set(1, "D");
+
+        assertTrue(haveEqualElements(refAll, property));
+        verify(listener).valuesChanged(eq(property), eq(1), matches(Collections.singletonList("B")), matches(Collections.singletonList("D")));
+        verifyNoMoreInteractions(listener);
+    }
+
+    @Test
     public void testRemoveAll() {
         List<Integer> refAll = new ArrayList<Integer>();
         refAll.add(1);


### PR DESCRIPTION
Hi Patrick,

We noticed a case where `ListValueChangeListener` is called with the wrong value. Here is a testcase and fix for the issue.

Maarten