### PR TITLE
Add minimum time visible to IconComponentDecoration tooltip

### DIFF
--- a/validationframework-swing/src/main/java/com/google/code/validationframework/swing/decoration/IconComponentDecoration.java
+++ b/validationframework-swing/src/main/java/com/google/code/validationframework/swing/decoration/IconComponentDecoration.java
@@ -321,6 +321,11 @@ public class IconComponentDecoration extends AbstractComponentDecoration {
         // Update tooltip dialog visibility if changed
         if ((toolTipDialog != null) && (toolTipDialog.isVisible() != shouldBeVisible)) {
             toolTipDialog.setVisible(shouldBeVisible);
+            if (!shouldBeVisible) {
+                // Workaround for https://bugs.openjdk.org/browse/JDK-8173332 in case the visibility is set to false too
+                // quickly after it has been set to true. Otherwise, the tooltip might stay visible
+                toolTipDialog.dispose();
+            }
         }
     }
 


### PR DESCRIPTION
Hello Patrick,

We found that when you quickly mouse over a validation icon, the tool-tip sometimes persists. It seems that the operating system may not have enough time in between the `window.setVisible(true)` and `window.setVisible(false)` to process its own stuff. This problem occurs around 25 ms delay. 50 ms seems to be safe, so I took 100 ms as minimum delay for good measure. This also still feels good when quickly mousing over.

I hope this fix is satisfactory.

Regards,
Wijtse